### PR TITLE
added target in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly-2021-04-01"
+targets = ["riscv64gc-unknown-none-elf"]


### PR DESCRIPTION
I'm using the rustc version of the newest nightly and when I tries to run this it tells me there is no installed target of `riscv64gc-unknown-none-elf`, so this project is not totally runnable (at least for user like me). I later found that in `rust-toolchain.toml` there is no target specified, so that cargo will not install the riscv target on the toolchain in this file.

I added the target in this file, so that when user uses `cargo run`, the target will be installed automatically.